### PR TITLE
Specify disk size for nodes in workload pools

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -82,6 +82,7 @@ Read-Only:
 Read-Only:
 
 - `autoscaling` (Attributes) Configuration options for the autoscaler. (see [below for nested schema](#nestedatt--workloadnodepools--autoscaling))
+- `disk` (Number) Size of disk for the node.  Defaults to 50GiB.
 - `flavor` (String) OpenStack flavor (size) for nodes in this pool.
 - `image` (String) Operating system image to use.  Must be a valid and signed ECK image.
 - `name` (String) Name of the workload pool.

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -95,6 +95,7 @@ Required:
 Optional:
 
 - `autoscaling` (Attributes) Configuration options for the autoscaler. (see [below for nested schema](#nestedatt--workloadnodepools--autoscaling))
+- `disk` (Number) Size of disk for the node.  Defaults to 50GiB.
 - `version` (String)
 
 <a id="nestedatt--workloadnodepools--autoscaling"></a>

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -61,6 +61,7 @@ type controlPlaneNodesModel struct {
 
 type workloadNodePoolModel struct {
 	Name        types.String      `tfsdk:"name"`
+	Disk        types.Int64       `tfsdk:"disk"`
 	Flavor      types.String      `tfsdk:"flavor"`
 	Image       types.String      `tfsdk:"image"`
 	Replicas    types.Int64       `tfsdk:"replicas"`
@@ -236,6 +237,10 @@ func (d *clusterDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 						"name": schema.StringAttribute{
 							Computed:    true,
 							Description: "Name of the workload pool.",
+						},
+						"disk": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Size of disk for the node.  Defaults to 50GiB.",
 						},
 						"flavor": schema.StringAttribute{
 							Computed:    true,

--- a/internal/provider/cluster_functions.go
+++ b/internal/provider/cluster_functions.go
@@ -108,6 +108,9 @@ func generateWorkloadNodePools(pools []workloadNodePoolModel) generated.Kubernet
 			workloadNodePools = append(workloadNodePools, generated.KubernetesClusterWorkloadPool{
 				Name: pool.Name.ValueString(),
 				Machine: generated.OpenstackMachinePool{
+					Disk: &generated.OpenstackVolume{
+						Size: int(pool.Disk.ValueInt64()),
+					},
 					Replicas:   int(pool.Replicas.ValueInt64()),
 					FlavorName: pool.Flavor.ValueString(),
 					ImageName:  pool.Image.ValueString(),
@@ -122,6 +125,9 @@ func generateWorkloadNodePools(pools []workloadNodePoolModel) generated.Kubernet
 			workloadNodePools = append(workloadNodePools, generated.KubernetesClusterWorkloadPool{
 				Name: pool.Name.ValueString(),
 				Machine: generated.OpenstackMachinePool{
+					Disk: &generated.OpenstackVolume{
+						Size: int(pool.Disk.ValueInt64()),
+					},
 					Replicas:   int(pool.Replicas.ValueInt64()),
 					FlavorName: pool.Flavor.ValueString(),
 					ImageName:  pool.Image.ValueString(),
@@ -139,6 +145,7 @@ func generateWorkloadNodePoolModel(workloadpools generated.KubernetesClusterWork
 		if pool.Autoscaling != nil {
 			workloadPools = append(workloadPools, workloadNodePoolModel{
 				Name:     types.StringValue(pool.Name),
+				Disk:     types.Int64Value(int64(pool.Machine.Disk.Size)),
 				Flavor:   types.StringValue(pool.Machine.FlavorName),
 				Image:    types.StringValue(pool.Machine.ImageName),
 				Replicas: types.Int64Value(int64(pool.Machine.Replicas)),
@@ -151,6 +158,7 @@ func generateWorkloadNodePoolModel(workloadpools generated.KubernetesClusterWork
 		} else {
 			workloadPools = append(workloadPools, workloadNodePoolModel{
 				Name:     types.StringValue(pool.Name),
+				Disk:     types.Int64Value(int64(pool.Machine.Disk.Size)),
 				Flavor:   types.StringValue(pool.Machine.FlavorName),
 				Image:    types.StringValue(pool.Machine.ImageName),
 				Replicas: types.Int64Value(int64(pool.Machine.Replicas)),

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -190,6 +191,12 @@ func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						"name": schema.StringAttribute{
 							Description: "Name of the workload pool.",
 							Required:    true,
+						},
+						"disk": schema.Int64Attribute{
+							Computed:    true,
+							Optional:    true,
+							Description: "Size of disk for the node.  Defaults to 50GiB.",
+							Default:     int64default.StaticInt64(50),
 						},
 						"flavor": schema.StringAttribute{
 							Description: "OpenStack flavor (size) for nodes in this pool.",


### PR DESCRIPTION
Previously this wasn't set, which the ECK API accepted, however some clients like the web UI expect the cluster definition to have a value here.

Mimic the web UI (since that's the canonical client) and default to 50GB of persistent storage.