### PR TITLE
Add a 'wait' option for cluster creation

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -25,6 +25,7 @@ description: |-
 
 - `clusterfeatures` (Attributes) Extra features allowing management of additional Kubernetes features that are considered standard. (see [below for nested schema](#nestedatt--clusterfeatures))
 - `clusteropenstack` (Attributes) (see [below for nested schema](#nestedatt--clusteropenstack))
+- `wait` (Boolean) Whether to wait for the cluster to be provisioned
 - `workloadnodepools` (Attributes List) (see [below for nested schema](#nestedatt--workloadnodepools))
 
 ### Read-Only

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -40,6 +40,7 @@ type clusterModel struct {
 	Kubeconfig        types.String            `tfsdk:"kubeconfig"`
 	Name              types.String            `tfsdk:"name"`
 	Status            types.String            `tfsdk:"status"`
+	Wait              types.Bool              `tfsdk:"wait"`
 	WorkloadNodePools []workloadNodePoolModel `tfsdk:"workloadnodepools"`
 }
 
@@ -329,7 +330,7 @@ func (d *clusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	}
 
 	// Map response body to model
-	state = generateClusterModel(ctx, cluster, state.EckCp.ValueString(), string(kubeconfig))
+	state = generateClusterModel(ctx, cluster, state.EckCp.ValueString(), string(kubeconfig), state.Wait.ValueBool())
 
 	// Set state
 	diags := resp.State.Set(ctx, &state)

--- a/internal/provider/cluster_functions.go
+++ b/internal/provider/cluster_functions.go
@@ -83,7 +83,7 @@ func generateKubernetesCluster(ctx context.Context, plan clusterModel) generated
 
 }
 
-func generateClusterModel(ctx context.Context, cluster generated.KubernetesCluster, eckcp string, kubeconfig string) clusterModel {
+func generateClusterModel(ctx context.Context, cluster generated.KubernetesCluster, eckcp string, kubeconfig string, wait bool) clusterModel {
 	ns, _ := types.ListValueFrom(ctx, types.StringType, cluster.Network.DnsNameservers)
 	clusterModel := clusterModel{
 		Name:              types.StringValue(cluster.Name),
@@ -91,6 +91,7 @@ func generateClusterModel(ctx context.Context, cluster generated.KubernetesClust
 		Status:            types.StringValue(cluster.Status.Status),
 		EckCp:             types.StringValue(eckcp),
 		Kubeconfig:        types.StringValue(kubeconfig),
+		Wait:              types.BoolValue(wait),
 		ControlPlane: &controlPlaneNodesModel{
 			Flavor:   types.StringValue(cluster.ControlPlane.FlavorName),
 			Image:    types.StringValue(cluster.ControlPlane.ImageName),


### PR DESCRIPTION
Introduce a new 'wait' option which blocks until the cluster has reached the 'Provisioned' status.  Defaults to false.